### PR TITLE
Split on the last hyphen

### DIFF
--- a/s3pypi/package.py
+++ b/s3pypi/package.py
@@ -17,7 +17,6 @@ class Package(object):
     """Python package archive."""
 
     def __init__(self, name, files):
-        print name
         self.name, self.version = name.rsplit('-', 1)
         self.files = set(files)
 

--- a/s3pypi/package.py
+++ b/s3pypi/package.py
@@ -17,7 +17,8 @@ class Package(object):
     """Python package archive."""
 
     def __init__(self, name, files):
-        self.name, self.version = name.split('-')
+        print name
+        self.name, self.version = name.rsplit('-', 1)
         self.files = set(files)
 
     def __str__(self):


### PR DESCRIPTION
Namespace packages are likely to contain hyphens to differentiate between the namespaces (see https://github.com/Azure/azure-sdk-for-python as an example).

The name and version should split on the last hyphen in the package name to support this.