### PR TITLE
Add decode method call to text variable

### DIFF
--- a/s3pypi/package.py
+++ b/s3pypi/package.py
@@ -38,7 +38,7 @@ class Package(object):
 
     @staticmethod
     def _find_package_name(text):
-        match = re.search('^(copying files to|making hard links in) (.+)\.\.\.', text, flags=re.MULTILINE)
+        match = re.search('^(copying files to|making hard links in) (.+)\.\.\.', text.decode('utf-8'), flags=re.MULTILINE)
 
         if not match:
             raise RuntimeError('Package name not found in:\n' + text)


### PR DESCRIPTION
I was getting this error when I tried to run s3pypi:
"Traceback (most recent call last):
  File "/usr/local/bin/s3pypi", line 9, in <module>
    load_entry_point('s3pypi==0.2.0', 'console_scripts', 's3pypi')()
  File "/usr/local/lib/python3.5/dist-packages/s3pypi/cli.py", line 37, in main
    create_and_upload_package(args)
  File "/usr/local/lib/python3.5/dist-packages/s3pypi/cli.py", line 17, in create_and_upload_package
    package = Package.create(args.wheel)
  File "/usr/local/lib/python3.5/dist-packages/s3pypi/package.py", line 60, in create
    name = Package._find_package_name(stdout)
  File "/usr/local/lib/python3.5/dist-packages/s3pypi/package.py", line 41, in _find_package_name
    match = re.search('^(copying files to|making hard links in) (.+)\.\.\.', text, flags=re.MULTILINE)
  File "/usr/lib/python3.5/re.py", line 173, in search
    return _compile(pattern, flags).search(string)
TypeError: cannot use a string pattern on a bytes-like object"

I was able to fix this issue by adding ".decode('utf-8')" to the text variable that was passed into the search method.