### PR TITLE
Use ARN to refer to SSL server certificate (ACM)

### DIFF
--- a/cloudformation/s3-pypi.json
+++ b/cloudformation/s3-pypi.json
@@ -52,7 +52,7 @@
       "Type": "String"
     },
     "ServerCertificateId": {
-      "Description": "ID of the server certificate for the domain name (e.g. ASCAXXXXXXXXXXXXXXXXX)",
+      "Description": "ARN of the SSL server certificate for the domain name, must be registered in us-east-1",
       "Type": "String"
     }
   },
@@ -175,7 +175,7 @@
           ],
           "PriceClass": "PriceClass_100",
           "ViewerCertificate": {
-            "IamCertificateId": {
+            "AcmCertificateArn": {
               "Ref": "ServerCertificateId"
             },
             "MinimumProtocolVersion": "TLSv1",


### PR DESCRIPTION
It seems like AWS does not any longer support the IAM certificate ID when creating new SSL certificates, but now prefers AWS Certificate Manager (ACM), which hands out an ARN that can be referred to.  For details see: http://stackoverflow.com/questions/35914161/how-to-provision-a-cloudfront-distribution-with-an-acm-certificate-using-cloud-f