### PR TITLE
[fix] normalize package directory names

### DIFF
--- a/s3pypi/package.py
+++ b/s3pypi/package.py
@@ -36,6 +36,10 @@ class Package(object):
     def __hash__(self):
         return hash(self._attrs())
 
+    @property
+    def directory(self):
+        return re.sub('[-_.]+', '-', self.name)
+
     @staticmethod
     def _find_package_name(text):
         match = re.search('^(copying files to|making hard links in) (.+)\.\.\.', text, flags=re.MULTILINE)

--- a/s3pypi/storage.py
+++ b/s3pypi/storage.py
@@ -19,7 +19,7 @@ class S3Storage(object):
         self.secret = secret
 
     def _object(self, package, filename):
-        path = '%s/%s' % (package.name, filename)
+        path = '%s/%s' % (package.directory, filename)
         return self.s3.Object(self.bucket, '%s/%s' % (self.secret, path) if self.secret else path)
 
     def get_index(self, package):

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -44,3 +44,8 @@ def test_add_package_force():
     index = Index([pkg1])
     index.add_package(pkg2, force=True)
     assert index.packages == {pkg2}
+
+
+def test_directory_normalize_package_name():
+    pkg = Package('company.test-0.0.1', ['foo'])
+    assert pkg.directory == 'company-test'


### PR DESCRIPTION
When a package name contains dots or underscores pip will normalize it's name while looking the repository.

So if your package name is **company.test** pip will look at **http://example.com/company-test/**

This pull request normalize the directory name containing the package files.