### PR TITLE
Add support for bare package names as indexes

### DIFF
--- a/s3pypi/__init__.py
+++ b/s3pypi/__init__.py
@@ -1,2 +1,2 @@
 __prog__ = 's3pypi'
-__version__ = u'0.3.0'
+__version__ = u'0.4.0'

--- a/s3pypi/cli.py
+++ b/s3pypi/cli.py
@@ -15,7 +15,7 @@ __license__ = 'MIT'
 
 def create_and_upload_package(args):
     package = Package.create(args.wheel)
-    storage = S3Storage(args.bucket, args.secret, args.region)
+    storage = S3Storage(args.bucket, args.secret, args.region, args.bare)
 
     index = storage.get_index(package)
     index.add_package(package, args.force)
@@ -31,6 +31,7 @@ def parse_args(raw_args):
     p.add_argument('--region', help='S3 region')
     p.add_argument('--force', action='store_true', help='Overwrite existing packages')
     p.add_argument('--no-wheel', dest='wheel', action='store_false', help='Skip wheel distribution')
+    p.add_argument('--bare', action='store_true', help='Store index as bare package name')
     return p.parse_args(raw_args)
 
 


### PR DESCRIPTION
Allows use without S3 website hosting.

If you upload the index file as `secret/package/` instead of `secret/package/index.html`, you don't have to have website hosting enabled or a custom certificate. You can just point pip at `https://<bucketname>.s3.amazonaws.com/<secret>/`. This makes bucket setup significantly easier.

It might also be worth adding `--prefix` as an alternative for `--secret`, since all it's doing is placing your packages under a specific prefix - which is important if you're using your bucket to host multiple types of artifacts (yum repos, java packages, etc) - but I haven't included that here.