### PR TITLE
Add --private argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ aws cloudformation create-stack --stack-name STACK_NAME \
 Distributing packages
 ---------------------
 
-You can now use ``s3pypi`` to create Python packages and upload them to your S3 bucket. To hide packages from the public, you can specify a secret subdirectory using the ``--secret`` option:
+You can now use ``s3pypi`` to create Python packages and upload them to your S3 bucket. To hide packages from the public, you can use the ``--private`` option to prevent the packages from being accessible directly via the S3 bucket (they will only be accessible via Cloudfront and you can use WAF rules to protect them), or alternatively you can specify a secret subdirectory using the ``--secret`` option:
 
 ```bash
 cd /path/to/your/awesome-project/
-s3pypi --bucket mybucket [--secret SECRET]
+s3pypi --bucket mybucket [--private] [--secret SECRET]
 ```
 
 

--- a/s3pypi/cli.py
+++ b/s3pypi/cli.py
@@ -15,7 +15,7 @@ __license__ = 'MIT'
 
 def create_and_upload_package(args):
     package = Package.create(args.wheel)
-    storage = S3Storage(args.bucket, args.secret, args.region, args.bare)
+    storage = S3Storage(args.bucket, args.secret, args.region, args.bare, args.private)
 
     index = storage.get_index(package)
     index.add_package(package, args.force)
@@ -32,6 +32,7 @@ def parse_args(raw_args):
     p.add_argument('--force', action='store_true', help='Overwrite existing packages')
     p.add_argument('--no-wheel', dest='wheel', action='store_false', help='Skip wheel distribution')
     p.add_argument('--bare', action='store_true', help='Store index as bare package name')
+    p.add_argument('--private', action='store_true', help='Store S3 Keys as private objects')
     return p.parse_args(raw_args)
 
 

--- a/s3pypi/storage.py
+++ b/s3pypi/storage.py
@@ -13,11 +13,12 @@ __license__ = 'MIT'
 class S3Storage(object):
     """Abstraction for storing package archives and index files in an S3 bucket."""
 
-    def __init__(self, bucket, secret=None, region=None, bare=False):
+    def __init__(self, bucket, secret=None, region=None, bare=False, private=False):
         self.s3 = boto3.resource('s3', region_name=region)
         self.bucket = bucket
         self.secret = secret
         self.index = '' if bare else 'index.html'
+        self.acl = 'private' if private else 'public-read'
 
     def _object(self, package, filename):
         path = '%s/%s' % (package.directory, filename)
@@ -35,7 +36,7 @@ class S3Storage(object):
             Body=index.to_html(),
             ContentType='text/html',
             CacheControl='public, must-revalidate, proxy-revalidate, max-age=0',
-            ACL='public-read'
+            ACL=self.acl
         )
 
     def put_package(self, package):
@@ -44,5 +45,5 @@ class S3Storage(object):
                 self._object(package, filename).put(
                     Body=f,
                     ContentType='application/x-gzip',
-                    ACL='public-read'
+                    ACL=self.acl
                 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,11 @@ def secret():
     return ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(24))
 
 
+@pytest.fixture(scope='function')
+def private():
+    return True
+
+
 @pytest.fixture(scope='function', params=['helloworld-0.1', 's3pypi-0.1.3'])
 def sdist_output(request):
     with open(os.path.join('tests', 'data', 'sdist_output', request.param)) as f:

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -6,3 +6,9 @@ def test_secret_in_s3_key(secret):
     storage = S3Storage('appstrakt-pypi', secret)
     package = Package('test-0.1.0', [])
     assert secret in storage._object(package, 'index.html').key
+    assert storage.acl == 'public-read'
+
+
+def test_private_s3_key(private):
+    storage = S3Storage('appstrakt-pypi', private=private)
+    assert storage.acl == 'private'


### PR DESCRIPTION
This allows for uploads of packages and index.html files  to your pypi repository to be marked
as private, and therefore ONLY accessible via the Cloudfront
distribution.  This also negates the need for the `--secret` argument
since these assets will not be available directly from the S3 bucket,
but I decided to leave that argument alone for backwards compatibility.