### PR TITLE
Add support for S3 Server-Side Encryption

### DIFF
--- a/s3pypi/cli.py
+++ b/s3pypi/cli.py
@@ -15,7 +15,7 @@ __license__ = 'MIT'
 
 def create_and_upload_package(args):
     package = Package.create(args.wheel)
-    storage = S3Storage(args.bucket, args.secret, args.region, args.bare, args.private)
+    storage = S3Storage(args.bucket, args.secret, args.region, args.bare, args.private, args.sse)
 
     index = storage.get_index(package)
     index.add_package(package, args.force)
@@ -33,6 +33,7 @@ def parse_args(raw_args):
     p.add_argument('--no-wheel', dest='wheel', action='store_false', help='Skip wheel distribution')
     p.add_argument('--bare', action='store_true', help='Store index as bare package name')
     p.add_argument('--private', action='store_true', help='Store S3 Keys as private objects')
+    p.add_argument('--sse', action='store_true', help='Enable S3 server side encryption')
     return p.parse_args(raw_args)
 
 

--- a/s3pypi/storage.py
+++ b/s3pypi/storage.py
@@ -13,12 +13,13 @@ __license__ = 'MIT'
 class S3Storage(object):
     """Abstraction for storing package archives and index files in an S3 bucket."""
 
-    def __init__(self, bucket, secret=None, region=None, bare=False, private=False):
+    def __init__(self, bucket, secret=None, region=None, bare=False, private=False, sse=False):
         self.s3 = boto3.resource('s3', region_name=region)
         self.bucket = bucket
         self.secret = secret
         self.index = '' if bare else 'index.html'
         self.acl = 'private' if private else 'public-read'
+        self.sse = sse
 
     def _object(self, package, filename):
         path = '%s/%s' % (package.directory, filename)
@@ -32,18 +33,28 @@ class S3Storage(object):
             return Index([])
 
     def put_index(self, package, index):
-        self._object(package, self.index).put(
-            Body=index.to_html(),
-            ContentType='text/html',
-            CacheControl='public, must-revalidate, proxy-revalidate, max-age=0',
-            ACL=self.acl
-        )
+        params = {
+            'Body': index.to_html(),
+            'ContentType': 'text/html',
+            'CacheControl': 'public, must-revalidate, proxy-revalidate, max-age=0',
+            'ACL': self.acl,
+        }
+
+        if self.sse:
+            params['ServerSideEncryption'] = 'AES256'
+
+        self._object(package, self.index).put(**params)
 
     def put_package(self, package):
         for filename in package.files:
             with open(os.path.join('dist', filename), mode='rb') as f:
-                self._object(package, filename).put(
-                    Body=f,
-                    ContentType='application/x-gzip',
-                    ACL=self.acl
-                )
+                params = {
+                    'Body': f,
+                    'ContentType': 'application/x-gzip',
+                    'ACL': self.acl,
+                }
+
+                if self.sse:
+                    params['ServerSideEncryption'] = 'AES256'
+
+                self._object(package, filename).put(**params)


### PR DESCRIPTION
The `--sse` argument mirrors the same argument of the [AWS CLI](https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html).