### PR TITLE
Add --no-sdist option for wheel-only builds

### DIFF
--- a/s3pypi/cli.py
+++ b/s3pypi/cli.py
@@ -14,7 +14,7 @@ __license__ = 'MIT'
 
 
 def create_and_upload_package(args):
-    package = Package.create(args.wheel)
+    package = Package.create(args.wheel, args.sdist)
     storage = S3Storage(args.bucket, args.secret, args.region, args.bare, args.private)
 
     index = storage.get_index(package)
@@ -31,6 +31,7 @@ def parse_args(raw_args):
     p.add_argument('--region', help='S3 region')
     p.add_argument('--force', action='store_true', help='Overwrite existing packages')
     p.add_argument('--no-wheel', dest='wheel', action='store_false', help='Skip wheel distribution')
+    p.add_argument('--no-sdist', dest='sdist', action='store_false', help='Skip sdist distribution')
     p.add_argument('--bare', action='store_true', help='Store index as bare package name')
     p.add_argument('--private', action='store_true', help='Store S3 Keys as private objects')
     return p.parse_args(raw_args)

--- a/s3pypi/package.py
+++ b/s3pypi/package.py
@@ -50,7 +50,7 @@ class Package(object):
         return match.group(2)
 
     @staticmethod
-    def create(wheel=True):
+    def create(wheel=True, sdist=True):
         cmd = ['python', 'setup.py', 'sdist', '--formats', 'gztar']
 
         if wheel:
@@ -61,8 +61,10 @@ class Package(object):
         except CalledProcessError as e:
             raise RuntimeError(e.output.rstrip())
 
+        files = []
         name = Package._find_package_name(stdout)
-        files = [name + '.tar.gz']
+        if sdist:
+            files.append([name + '.tar.gz'])
 
         if wheel:
             files.extend(os.path.basename(path) for path in


### PR DESCRIPTION
I'm repackaging a couple of packages with extension modules that build outside of distutils. I've created a setup.py script to build a wheel but the sdist is not usable on its own.

This still runs the sdist distutils command to get the package name from
output, but the file is no longer uploaded.