### PR TITLE
Fixed entry points / use standard name __main__ so that can be run wi…

### DIFF
--- a/s3pypi/__main__.py
+++ b/s3pypi/__main__.py
@@ -46,3 +46,7 @@ def main():
     except S3PyPiError as e:
         print('error: %s' % e)
         sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,5 @@ setup(
     package_data={__prog__: ['templates/*.j2']},
 
     install_requires=['boto3', 'Jinja2', 'wheel'],
-    entry_points={'console_scripts': ['{0}={0}.cli:main'.format(__prog__)]},
+    entry_points={'console_scripts': ['{0}={0}.__main__:main'.format(__prog__)]},
 )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,6 +1,6 @@
 import pytest
 
-from s3pypi.cli import parse_args
+from s3pypi.__main__ import parse_args
 
 
 def test_cli_argparser_raises_no_exceptions():


### PR DESCRIPTION
This allows the tool to be run via `python -m s3pypi`