### PR TITLE
Verbose/version flags and fix for no Python2.x install

### DIFF
--- a/s3pypi/__init__.py
+++ b/s3pypi/__init__.py
@@ -1,2 +1,2 @@
 __prog__ = 's3pypi'
-__version__ = u'0.7.1'
+__version__ = u'0.7.2'

--- a/s3pypi/__main__.py
+++ b/s3pypi/__main__.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import argparse
 import sys
 
-from s3pypi import __prog__
+from s3pypi import __prog__, __version__
 from s3pypi.exceptions import S3PyPiError
 from s3pypi.package import Package
 from s3pypi.storage import S3Storage
@@ -14,8 +14,8 @@ __license__ = 'MIT'
 
 
 def create_and_upload_package(args):
-    package = Package.create(args.wheel, args.sdist)
-    storage = S3Storage(args.bucket, args.secret, args.region, args.bare, args.private, args.profile)
+    package = Package.create(args.wheel, args.sdist, args.verbose)
+    storage = S3Storage(args.bucket, args.secret, args.region, args.bare, args.private, args.profile, args.verbose)
 
     index = storage.get_index(package)
     index.add_package(package, args.force)
@@ -35,11 +35,17 @@ def parse_args(raw_args):
     p.add_argument('--no-sdist', dest='sdist', action='store_false', help='Skip sdist distribution')
     p.add_argument('--bare', action='store_true', help='Store index as bare package name')
     p.add_argument('--private', action='store_true', help='Store S3 Keys as private objects')
+    p.add_argument('--verbose', action='store_true', help='Turn on verbose output.')
+    p.add_argument('--version', action='store_true', help='Show s3pypi version.')
     return p.parse_args(raw_args)
 
 
 def main():
     args = parse_args(sys.argv[1:])
+
+    if args.version:
+        print("s3pypi v{}".format(__version__))
+        sys.exit(0)
 
     try:
         create_and_upload_package(args)

--- a/s3pypi/__main__.py
+++ b/s3pypi/__main__.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import argparse
 import sys
+import logging
 
 from s3pypi import __prog__, __version__
 from s3pypi.exceptions import S3PyPiError
@@ -12,10 +13,12 @@ __author__ = 'Matteo De Wint'
 __copyright__ = 'Copyright 2016, November Five'
 __license__ = 'MIT'
 
+log = logging.getLogger()
+
 
 def create_and_upload_package(args):
-    package = Package.create(args.wheel, args.sdist, args.verbose)
-    storage = S3Storage(args.bucket, args.secret, args.region, args.bare, args.private, args.profile, args.verbose)
+    package = Package.create(args.wheel, args.sdist)
+    storage = S3Storage(args.bucket, args.secret, args.region, args.bare, args.private, args.profile)
 
     index = storage.get_index(package)
     index.add_package(package, args.force)
@@ -36,16 +39,14 @@ def parse_args(raw_args):
     p.add_argument('--bare', action='store_true', help='Store index as bare package name')
     p.add_argument('--private', action='store_true', help='Store S3 Keys as private objects')
     p.add_argument('--verbose', action='store_true', help='Turn on verbose output.')
-    p.add_argument('--version', action='store_true', help='Show s3pypi version.')
+    p.add_argument('--version', action='version', version=__version__)
     return p.parse_args(raw_args)
 
 
 def main():
     args = parse_args(sys.argv[1:])
 
-    if args.version:
-        print("s3pypi v{}".format(__version__))
-        sys.exit(0)
+    log.setLevel(logging.DEBUG if args.verbose else logging.INFO)
 
     try:
         create_and_upload_package(args)

--- a/s3pypi/package.py
+++ b/s3pypi/package.py
@@ -14,6 +14,8 @@ __author__ = 'Matteo De Wint'
 __copyright__ = 'Copyright 2016, November Five'
 __license__ = 'MIT'
 
+log = logging.getLogger()
+
 
 class Package(object):
     """Python package."""
@@ -60,22 +62,20 @@ class Package(object):
         return match.group(1)
 
     @staticmethod
-    def create(wheel=True, sdist=True, verbose=False):
+    def create(wheel=True, sdist=True):
         cmd = [sys.executable, 'setup.py', 'sdist', '--formats', 'gztar']
 
         if wheel:
             cmd.append('bdist_wheel')
 
-        if verbose:
-            print("Package create command line: {}".format(' '.join(cmd)))
+        log.debug("Package create command line: {}".format(' '.join(cmd)))
             
         try:
             stdout = check_output(cmd).decode().strip()
         except CalledProcessError as e:
             raise RuntimeError(e.output.rstrip())
 
-        if verbose:
-            print(stdout)
+        log.debug(stdout)
             
         name = Package._find_package_name(stdout)
         files = []
@@ -86,9 +86,8 @@ class Package(object):
         if wheel:
             files.append(os.path.basename(Package._find_wheel_name(stdout)))
 
-        if verbose:
-            print("Package name: {}".format(name))
-            print("Files to upload: {}".format(files))
+        log.debug("Package name: {}".format(name))
+        log.debug("Files to upload: {}".format(files))
             
         return Package(name, files)
 

--- a/s3pypi/storage.py
+++ b/s3pypi/storage.py
@@ -1,4 +1,5 @@
 import os
+import logging
 
 import boto3
 from botocore.exceptions import ClientError
@@ -9,11 +10,13 @@ __author__ = 'Matteo De Wint'
 __copyright__ = 'Copyright 2016, November Five'
 __license__ = 'MIT'
 
+log = logging.getLogger()
+
 
 class S3Storage(object):
     """Abstraction for storing package archives and index files in an S3 bucket."""
 
-    def __init__(self, bucket, secret=None, region=None, bare=False, private=False, profile=None, verbose=False):
+    def __init__(self, bucket, secret=None, region=None, bare=False, private=False, profile=None):
         if profile:
             boto3.setup_default_session(profile_name=profile)        
         self.s3 = boto3.resource('s3', region_name=region)
@@ -21,7 +24,6 @@ class S3Storage(object):
         self.secret = secret
         self.index = '' if bare else 'index.html'
         self.acl = 'private' if private else 'public-read'
-        self.verbose = verbose
 
     def _object(self, package, filename):
         path = '%s/%s' % (package.directory, filename)
@@ -44,8 +46,7 @@ class S3Storage(object):
 
     def put_package(self, package):
         for filename in package.files:
-            if self.verbose:
-                print("Uploading file `{}`...".format(filename))
+            log.debug("Uploading file `{}`...".format(filename))
             with open(os.path.join('dist', filename), mode='rb') as f:
                 self._object(package, filename).put(
                     Body=f,

--- a/s3pypi/storage.py
+++ b/s3pypi/storage.py
@@ -13,7 +13,7 @@ __license__ = 'MIT'
 class S3Storage(object):
     """Abstraction for storing package archives and index files in an S3 bucket."""
 
-    def __init__(self, bucket, secret=None, region=None, bare=False, private=False, profile=None):
+    def __init__(self, bucket, secret=None, region=None, bare=False, private=False, profile=None, verbose=False):
         if profile:
             boto3.setup_default_session(profile_name=profile)        
         self.s3 = boto3.resource('s3', region_name=region)
@@ -21,6 +21,7 @@ class S3Storage(object):
         self.secret = secret
         self.index = '' if bare else 'index.html'
         self.acl = 'private' if private else 'public-read'
+        self.verbose = verbose
 
     def _object(self, package, filename):
         path = '%s/%s' % (package.directory, filename)
@@ -43,6 +44,8 @@ class S3Storage(object):
 
     def put_package(self, package):
         for filename in package.files:
+            if self.verbose:
+                print("Uploading file `{}`...".format(filename))
             with open(os.path.join('dist', filename), mode='rb') as f:
                 self._object(package, filename).put(
                     Body=f,


### PR DESCRIPTION
1) Add —verbose flag to assist with debugging any issues encountered running the tool (esp. regex misses with setup.py output - https://github.com/novemberfiveco/s3pypi/issues/39).
2) Add —version flag
3) Use current python interpreter to run setup.py (Exsisting code was running `python` instead of the current python interpreter that the s3pypi was running under. In some contexts, python2.x is not installed (the issue I had), and it's prob. a good idea to use the same interpreter anyway - might resolve https://github.com/novemberfiveco/s3pypi/issues/38).
4) Bump to v0.7.2