### PR TITLE
Fix; Wheels of packages with 'dist' in the name couldn't be found.

### DIFF
--- a/s3pypi/package.py
+++ b/s3pypi/package.py
@@ -54,7 +54,7 @@ class Package(object):
 
     @staticmethod
     def _find_wheel_name(text):
-        match = re.search("creating '.*(dist.*\.whl)' and adding", text, flags=re.MULTILINE)
+        match = re.search("creating '.*?(dist.*\.whl)' and adding", text, flags=re.MULTILINE)
 
         if not match:
             raise RuntimeError('Wheel name not found! (use --verbose to view output)')

--- a/s3pypi/package.py
+++ b/s3pypi/package.py
@@ -41,11 +41,11 @@ class Package(object):
 
     @property
     def directory(self):
-        return re.sub('[-_.]+', '-', self.name)
+        return re.sub(r'[-_.]+', '-', self.name)
 
     @staticmethod
     def _find_package_name(text):
-        match = re.search('^(copying files to|making hard links in) (.+)\.\.\.', text, flags=re.MULTILINE)
+        match = re.search(r'^(copying files to|making hard links in) (.+)\.\.\.', text, flags=re.MULTILINE)
 
         if not match:
             raise RuntimeError('Package name not found! (use --verbose to view output)')
@@ -54,7 +54,7 @@ class Package(object):
 
     @staticmethod
     def _find_wheel_name(text):
-        match = re.search("creating '.*?(dist.*\.whl)' and adding", text, flags=re.MULTILINE)
+        match = re.search(r"creating '.*?(dist.*\.whl)' and adding", text, flags=re.MULTILINE)
 
         if not match:
             raise RuntimeError('Wheel name not found! (use --verbose to view output)')
@@ -104,7 +104,7 @@ class Index(object):
     def parse(html):
         filenames = defaultdict(set)
 
-        for match in re.findall('<a href="((.+?-\d+\.\d+\.\d+).+)">', html):
+        for match in re.findall(r'<a href="((.+?-\d+\.\d+\.\d+).+)">', html):
             filenames[match[1]].add(match[0])
 
         return Index(Package(name, files) for name, files in filenames.items())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,10 +17,16 @@ def private():
     return True
 
 
-@pytest.fixture(scope='function', params=['helloworld-0.1', 's3pypi-0.1.3'])
+@pytest.fixture(scope='function', params=['helloworld-0.1', 's3pypi-0.1.3', 'distribution_costs-0.1.0'])
 def sdist_output(request):
     with open(os.path.join('tests', 'data', 'sdist_output', request.param)) as f:
         yield f.read(), request.param
+
+
+@pytest.fixture(scope='function', params=['distribution_costs-0.1.0'])
+def bdist_wheel_output(request):
+    with open(os.path.join('tests', 'data', 'sdist_output', request.param)) as f:
+        yield f.read(), 'dist/{}-py3-none-any.whl'.format(request.param)
 
 
 @pytest.fixture(scope='function', params=[

--- a/tests/data/sdist_output/distribution_costs-0.1.0
+++ b/tests/data/sdist_output/distribution_costs-0.1.0
@@ -1,0 +1,63 @@
+running sdist
+running egg_info
+creating distribution_costs.egg-info
+writing distribution_costs.egg-info/PKG-INFO
+writing dependency_links to distribution_costs.egg-info/dependency_links.txt
+writing requirements to distribution_costs.egg-info/requires.txt
+writing top-level names to distribution_costs.egg-info/top_level.txt
+writing manifest file 'distribution_costs.egg-info/SOURCES.txt'
+package init file 'gorilla/formulas/__init__.py' not found (or not a regular file)
+reading manifest file 'distribution_costs.egg-info/SOURCES.txt'
+writing manifest file 'distribution_costs.egg-info/SOURCES.txt'
+warning: sdist: standard file not found: should have one of README, README.rst, README.txt, README.md
+
+running check
+warning: check: missing required meta-data: url
+
+creating distribution_costs-0.1.0
+creating distribution_costs-0.1.0/gorilla
+creating distribution_costs-0.1.0/gorilla/formulas
+creating distribution_costs-0.1.0/distribution_costs.egg-info
+copying files to distribution_costs-0.1.0...
+copying setup.py -> distribution_costs-0.1.0
+copying gorilla/formulas/bo_distribution_costs.py -> distribution_costs-0.1.0/gorilla/formulas
+copying distribution_costs.egg-info/PKG-INFO -> distribution_costs-0.1.0/distribution_costs.egg-info
+copying distribution_costs.egg-info/SOURCES.txt -> distribution_costs-0.1.0/distribution_costs.egg-info
+copying distribution_costs.egg-info/dependency_links.txt -> distribution_costs-0.1.0/distribution_costs.egg-info
+copying distribution_costs.egg-info/requires.txt -> distribution_costs-0.1.0/distribution_costs.egg-info
+copying distribution_costs.egg-info/top_level.txt -> distribution_costs-0.1.0/distribution_costs.egg-info
+Writing distribution_costs-0.1.0/setup.cfg
+creating dist
+Creating tar archive
+removing 'distribution_costs-0.1.0' (and everything under it)
+running bdist_wheel
+running build
+running build_py
+creating build
+creating build/lib
+creating build/lib/gorilla
+creating build/lib/gorilla/formulas
+copying gorilla/formulas/bo_distribution_costs.py -> build/lib/gorilla/formulas
+warning: build_py: byte-compiling is disabled, skipping.
+
+installing to build/bdist.macosx-10.14-x86_64/wheel
+running install
+running install_lib
+creating build/bdist.macosx-10.14-x86_64
+creating build/bdist.macosx-10.14-x86_64/wheel
+creating build/bdist.macosx-10.14-x86_64/wheel/gorilla
+creating build/bdist.macosx-10.14-x86_64/wheel/gorilla/formulas
+copying build/lib/gorilla/formulas/bo_distribution_costs.py -> build/bdist.macosx-10.14-x86_64/wheel/gorilla/formulas
+warning: install_lib: byte-compiling is disabled, skipping.
+
+running install_egg_info
+Copying distribution_costs.egg-info to build/bdist.macosx-10.14-x86_64/wheel/distribution_costs-0.1.0-py3.7.egg-info
+running install_scripts
+creating build/bdist.macosx-10.14-x86_64/wheel/distribution_costs-0.1.0.dist-info/WHEEL
+creating 'dist/distribution_costs-0.1.0-py3-none-any.whl' and adding 'build/bdist.macosx-10.14-x86_64/wheel' to it
+adding 'gorilla/formulas/bo_distribution_costs.py'
+adding 'distribution_costs-0.1.0.dist-info/METADATA'
+adding 'distribution_costs-0.1.0.dist-info/WHEEL'
+adding 'distribution_costs-0.1.0.dist-info/top_level.txt'
+adding 'distribution_costs-0.1.0.dist-info/RECORD'
+removing build/bdist.macosx-10.14-x86_64/wheel

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -9,6 +9,11 @@ def test_find_package_name(sdist_output):
     assert Package._find_package_name(stdout) == expected_name
 
 
+def test_find_wheel_name(bdist_wheel_output):
+    stdout, expected_name = bdist_wheel_output
+    assert Package._find_wheel_name(stdout) == expected_name
+
+
 def test_parse_index(index_html):
     html, expected_packages = index_html
     assert Index.parse(html).packages == expected_packages


### PR DESCRIPTION
A regex that got too greedy made the wheel locator in package.py unable to locate wheels of packages that had 'dist' in the name. 
Also made sure that all regexes use raw strings.