### PR TITLE
pip requires lowercase path

### DIFF
--- a/s3pypi/package.py
+++ b/s3pypi/package.py
@@ -41,7 +41,7 @@ class Package(object):
 
     @property
     def directory(self):
-        return re.sub(r'[-_.]+', '-', self.name)
+        return re.sub(r'[-_.]+', '-', self.name.lower())
 
     @staticmethod
     def _find_package_name(text):


### PR DESCRIPTION
The object path for packages with upper or mixed case names should be lowercase.

Observe the behavior of pip install when a mixed case package name is specified:

```
$ pip -v install CherryPy
...
Collecting CherryPy
  1 location(s) to search for versions of CherryPy:
  * https://pypi.org/simple/cherrypy/
  Getting page https://pypi.org/simple/cherrypy/
...
```

Note that the URL contains `cherrypy` rather than `CherryPy`.