### PR TITLE
Update version matching to be PEP 0440 compliant

### DIFF
--- a/s3pypi/package.py
+++ b/s3pypi/package.py
@@ -104,7 +104,8 @@ class Index(object):
     def parse(html):
         filenames = defaultdict(set)
 
-        for match in re.findall(r'<a href=".+">((.+?-\d+\.\d+\.\d+).+)</a>', html):
+        for match in re.findall(r'<a href=".+">((.+?-((?:\d+!)?\d+(?:\.\d+)*(?:(?:a|b|rc)\d+)?(?:\.post\d+)?' +
+                                r'(?:\.dev\d+)?)(?:\+([a-zA-Z0-9\.]+))?).*(?:\.whl|\.tar\.gz))</a>', html):
             filenames[match[1]].add(match[0])
 
         return Index(Package(name, files) for name, files in filenames.items())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ def bdist_wheel_output(request):
 
 @pytest.fixture(scope='function', params=[
     ('s3pypi', {Package('s3pypi-' + v, {'s3pypi-%s.tar.gz' % v, 's3pypi-%s-py2-none-any.whl' % v})
-                for v in ('0.1.1', '0.1.2')})
+                for v in ('0', '0!0', '0+local', '0.0', '0.1.1', '0.1.2', '0.dev0', '0.post0', '0a0', '0rc0')})
 ])
 def index_html(request):
     name, packages = request.param

--- a/tests/data/index/s3pypi.html
+++ b/tests/data/index/s3pypi.html
@@ -5,9 +5,25 @@
     <title>Package Index</title>
 </head>
 <body>
+    <a href="s3pypi-0-py2-none-any.whl">s3pypi-0-py2-none-any.whl</a><br>
+    <a href="s3pypi-0.tar.gz">s3pypi-0.tar.gz</a><br>
+    <a href="s3pypi-0%210-py2-none-any.whl">s3pypi-0!0-py2-none-any.whl</a><br>
+    <a href="s3pypi-0%210.tar.gz">s3pypi-0!0.tar.gz</a><br>
+    <a href="s3pypi-0%2Blocal-py2-none-any.whl">s3pypi-0+local-py2-none-any.whl</a><br>
+    <a href="s3pypi-0%2Blocal.tar.gz">s3pypi-0+local.tar.gz</a><br>
+    <a href="s3pypi-0.0-py2-none-any.whl">s3pypi-0.0-py2-none-any.whl</a><br>
+    <a href="s3pypi-0.0.tar.gz">s3pypi-0.0.tar.gz</a><br>
     <a href="s3pypi-0.1.1-py2-none-any.whl">s3pypi-0.1.1-py2-none-any.whl</a><br>
     <a href="s3pypi-0.1.1.tar.gz">s3pypi-0.1.1.tar.gz</a><br>
     <a href="s3pypi-0.1.2-py2-none-any.whl">s3pypi-0.1.2-py2-none-any.whl</a><br>
     <a href="s3pypi-0.1.2.tar.gz">s3pypi-0.1.2.tar.gz</a><br>
+    <a href="s3pypi-0.dev0-py2-none-any.whl">s3pypi-0.dev0-py2-none-any.whl</a><br>
+    <a href="s3pypi-0.dev0.tar.gz">s3pypi-0.dev0.tar.gz</a><br>
+    <a href="s3pypi-0.post0-py2-none-any.whl">s3pypi-0.post0-py2-none-any.whl</a><br>
+    <a href="s3pypi-0.post0.tar.gz">s3pypi-0.post0.tar.gz</a><br>
+    <a href="s3pypi-0a0-py2-none-any.whl">s3pypi-0a0-py2-none-any.whl</a><br>
+    <a href="s3pypi-0a0.tar.gz">s3pypi-0a0.tar.gz</a><br>
+    <a href="s3pypi-0rc0-py2-none-any.whl">s3pypi-0rc0-py2-none-any.whl</a><br>
+    <a href="s3pypi-0rc0.tar.gz">s3pypi-0rc0.tar.gz</a><br>
 </body>
 </html>


### PR DESCRIPTION
---* Motivation *---
Previous version matching assumed versions were of the form \d+\.\d+\.\d+. Update to support the full Python standard.

---* Detailed Description *---
https://www.python.org/dev/peps/pep-0440/

---* Test Notes *---
Updated tests.