### PR TITLE
Adds 'dist-path' option to specify folder with pre-built distro

### DIFF
--- a/s3pypi/__main__.py
+++ b/s3pypi/__main__.py
@@ -17,7 +17,7 @@ log = logging.getLogger()
 
 
 def create_and_upload_package(args):
-    package = Package.create(args.wheel, args.sdist)
+    package = Package.create(args.wheel, args.sdist, args.dist_path)
     storage = S3Storage(args.bucket, args.secret, args.region, args.bare, args.private, args.profile)
 
     index = storage.get_index(package)
@@ -36,6 +36,7 @@ def parse_args(raw_args):
     p.add_argument('--force', action='store_true', help='Overwrite existing packages')
     p.add_argument('--no-wheel', dest='wheel', action='store_false', help='Skip wheel distribution')
     p.add_argument('--no-sdist', dest='sdist', action='store_false', help='Skip sdist distribution')
+    p.add_argument('--dist-path', dest='dist_path', help='Path to directory with wheel/sdist to be uploaded')
     p.add_argument('--bare', action='store_true', help='Store index as bare package name')
     p.add_argument('--private', action='store_true', help='Store S3 Keys as private objects')
     p.add_argument('--verbose', action='store_true', help='Turn on verbose output.')

--- a/s3pypi/package.py
+++ b/s3pypi/package.py
@@ -62,30 +62,36 @@ class Package(object):
         return match.group(1)
 
     @staticmethod
-    def create(wheel=True, sdist=True):
-        cmd = [sys.executable, 'setup.py', 'sdist', '--formats', 'gztar']
-
-        if wheel:
-            cmd.append('bdist_wheel')
-
-        log.debug("Package create command line: {}".format(' '.join(cmd)))
-
-        try:
-            stdout = check_output(cmd).decode().strip()
-        except CalledProcessError as e:
-            raise RuntimeError(e.output.rstrip())
-
-        log.debug(stdout)
-
-        name = Package._find_package_name(stdout)
+    def create(wheel=True, sdist=True, dist_path=None):
         files = []
+        if not dist_path:
+            cmd = [sys.executable, 'setup.py', 'sdist', '--formats', 'gztar']
 
-        if sdist:
-            files.append(name + '.tar.gz')
+            if wheel:
+                cmd.append('bdist_wheel')
 
-        if wheel:
-            files.append(os.path.basename(Package._find_wheel_name(stdout)))
+            log.debug("Package create command line: {}".format(' '.join(cmd)))
 
+            try:
+                stdout = check_output(cmd).decode().strip()
+            except CalledProcessError as e:
+                raise RuntimeError(e.output.rstrip())
+
+            log.debug(stdout)
+
+            name = Package._find_package_name(stdout)
+
+            if sdist:
+                files.append(name + '.tar.gz')
+
+            if wheel:
+                files.append(os.path.basename(Package._find_wheel_name(stdout)))
+        else:
+            for f in os.listdir(dist_path):
+                if f.endswith('.tar.gz'):
+                    name = f[:-7]
+                files.append(f)
+                
         log.debug("Package name: {}".format(name))
         log.debug("Files to upload: {}".format(files))
 


### PR DESCRIPTION
This PR addresses [#43](https://github.com/novemberfiveco/s3pypi/issues/43). I added an option to specify a directory with already built distros to allow compatibility with tools like [poetry](https://poetry.eustace.io/) that abstract away the setup.py. I'm currently using this fork to publish packages built using poetry. I've also verified I can successfully install packages published this way.