### PR TITLE
Added acl option, made acl and private options mutually exclusive

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ aws cloudformation create-stack --stack-name STACK_NAME \
 
 ### Distributing packages
 
-You can now use ``s3pypi`` to create Python packages and upload them to your S3 bucket. To hide packages from the public, you can use the ``--private`` option to prevent the packages from being accessible directly via the S3 bucket (they will only be accessible via Cloudfront and you can use WAF rules to protect them), or alternatively you can specify a secret subdirectory using the ``--secret`` option:
+You can now use ``s3pypi`` to create Python packages and upload them to your S3 bucket. To hide packages from the public, you can use the ``--private`` option to prevent the packages from being accessible directly via the S3 bucket (they will only be accessible via Cloudfront and you can use WAF rules to protect them). If switching between private and public is not flexible enough, you can use the ``--acl`` option to directly specify the ACL. Alternatively, you can specify a secret subdirectory using the ``--secret`` option:
 
 ```bash
 cd /path/to/your-project/
-s3pypi --bucket mybucket [--private] [--secret SECRET]
+s3pypi --bucket mybucket [--private | --acl ACL] [--secret SECRET]
 ```
 
 

--- a/s3pypi/__main__.py
+++ b/s3pypi/__main__.py
@@ -14,8 +14,9 @@ log = logging.getLogger()
 
 def create_and_upload_package(args):
     package = Package.create(args.wheel, args.sdist, args.dist_path)
+
     storage = S3Storage(
-        args.bucket, args.secret, args.region, args.bare, args.private, args.profile
+        args.bucket, args.secret, args.region, args.bare, args.acl, args.profile
     )
 
     index = storage.get_index(package)
@@ -44,11 +45,24 @@ def parse_args(args):
     p.add_argument(
         "--bare", action="store_true", help="Store index as bare package name"
     )
-    p.add_argument(
-        "--private", action="store_true", help="Store S3 Keys as private objects"
+
+    acl_group = p.add_mutually_exclusive_group()
+
+    acl_group.add_argument(
+        "--private",
+        action="store_const",
+        const="private",
+        default="public-read",
+        dest="acl",
+        help="Store S3 Keys as private objects",
     )
+    acl_group.add_argument(
+        "--acl", default="public-read", help="ACL to use for S3 objects"
+    )
+
     p.add_argument("--verbose", action="store_true", help="Turn on verbose output.")
     p.add_argument("--version", action="version", version=__version__)
+
     return p.parse_args(args)
 
 

--- a/s3pypi/storage.py
+++ b/s3pypi/storage.py
@@ -13,7 +13,13 @@ class S3Storage(object):
     """Abstraction for storing package archives and index files in an S3 bucket."""
 
     def __init__(
-        self, bucket, secret=None, region=None, bare=False, private=False, profile=None
+        self,
+        bucket,
+        secret=None,
+        region=None,
+        bare=False,
+        acl="public-read",
+        profile=None,
     ):
         if profile:
             boto3.setup_default_session(profile_name=profile)
@@ -21,7 +27,7 @@ class S3Storage(object):
         self.bucket = bucket
         self.secret = secret
         self.index = "" if bare else "index.html"
-        self.acl = "private" if private else "public-read"
+        self.acl = acl
 
     def _object(self, package, filename):
         path = "%s/%s" % (package.directory, filename)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -14,11 +14,6 @@ def secret():
     )
 
 
-@pytest.fixture(scope="function")
-def private():
-    return True
-
-
 @pytest.fixture(
     scope="function",
     params=["helloworld-0.1", "s3pypi-0.1.3", "distribution_costs-0.1.0"],

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -7,3 +7,8 @@ def test_cli_argparser_raises_no_exceptions():
     """An invalid keyword to ArgumentParser was causing an exception in Python 3."""
     with pytest.raises(SystemExit):
         parse_args(None)
+
+
+def test_cli_argparser_raises_mutually_exclusive_exception():
+    with pytest.raises(SystemExit):
+        parse_args(["--bucket", "foo", "--acl", "public-read", "--private"])

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -7,8 +7,3 @@ def test_secret_in_s3_key(secret):
     package = Package("test-0.1.0", [])
     assert secret in storage._object(package, "index.html").key
     assert storage.acl == "public-read"
-
-
-def test_private_s3_key(private):
-    storage = S3Storage("appstrakt-pypi", private=private)
-    assert storage.acl == "private"


### PR DESCRIPTION
This fixes #71 by adding an additional `--acl` argument that lets you specify any of the [Canned ACLs](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) instead of just "public-read" and "private". The change moves the `--private` flag and the new `--acl` argument into a mutually exclusive group. This ensures that both arguments cannot be used at the same time, yet it maintains backwards compatibility (as the private flag can still be used just like before). 