### PR TITLE
Add option to lock indexes in S3 using DynamoDB & add option to put root index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 
 ### Changed
 
-- Set the default root object to `index.html` in CloudFront.
+- Set CloudFront default root object to `index.html`.
 
 
 ## 1.0.0rc1 - 2021-05-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 
 ### Added
 
-- `--lock-indexes` option to lock index objects in S3 using a DynamoDB table.
+- Terraform config for an optional DynamoDB table used for distributed locking.
+- `--lock-indexes` option to lock index objects in S3 using said DynamoDB table.
 - `--put-root-index` option to write a root index that lists all package names.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 - `--lock-indexes` option to lock index objects in S3 using a DynamoDB table.
 - `--put-root-index` option to write a root index that lists all package names.
 
+### Changed
+
+- Set the default root object to `index.html` in CloudFront.
+
 
 ## 1.0.0rc1 - 2021-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/).
 
 
+## Unreleased
+
+### Added
+
+- `--lock-indexes` option to lock index objects in S3 using a DynamoDB table.
+- `--put-root-index` option to write a root index that lists all package names.
+
+
 ## 1.0.0rc1 - 2021-05-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ your domain, with a matching (wildcard) certificate in [AWS Certificate
 Manager]. If your certificate is a wildcard certificate, add
 `use_wildcard_certificate = true` to `config.auto.tfvars`.
 
+#### Distributed locking with DynamoDB
+
+To ensure that concurrent invocations of `s3pypi` do not overwrite each other's
+changes, the objects in S3 can be locked via an optional DynamoDB table (using
+the `--lock-indexes` option). To create this table, add `enable_dynamodb_locking
+= true` to `config.auto.tfvars`.
+
 #### Basic authentication
 
 To enable basic authentication, add `enable_basic_auth = true` to
@@ -94,6 +101,7 @@ module "s3pypi" {
   domain = "pypi.example.com"
 
   use_wildcard_certificate = true
+  enable_dynamodb_locking  = true
   enable_basic_auth        = true
 
   providers = {

--- a/s3pypi/__main__.py
+++ b/s3pypi/__main__.py
@@ -56,6 +56,7 @@ def get_arg_parser():
             "This ensures that concurrent invocations of s3pypi do not overwrite each other's changes."
         ),
     )
+    p.add_argument("--put-root-index", action="store_true", help="Write a root index.")
     p.add_argument("-f", "--force", action="store_true", help="Overwrite files.")
     p.add_argument("-v", "--verbose", action="store_true", help="Verbose output.")
     p.add_argument("-V", "--version", action="version", version=__version__)

--- a/s3pypi/__main__.py
+++ b/s3pypi/__main__.py
@@ -47,6 +47,15 @@ def get_arg_parser():
             "It's recommended to instead use a private S3 bucket with a CloudFront Origin Access Identity."
         ),
     )
+    p.add_argument(
+        "-l",
+        "--lock-indexes",
+        action="store_true",
+        help=(
+            "Lock index objects in S3 using a DynamoDB table. "
+            "This ensures that concurrent invocations of s3pypi do not overwrite each other's changes."
+        ),
+    )
     p.add_argument("-f", "--force", action="store_true", help="Overwrite files.")
     p.add_argument("-v", "--verbose", action="store_true", help="Verbose output.")
     p.add_argument("-V", "--version", action="version", version=__version__)

--- a/s3pypi/__main__.py
+++ b/s3pypi/__main__.py
@@ -52,11 +52,15 @@ def get_arg_parser():
         "--lock-indexes",
         action="store_true",
         help=(
-            "Lock index objects in S3 using a DynamoDB table. "
+            "Lock index objects in S3 using a DynamoDB table named `<bucket>-locks`. "
             "This ensures that concurrent invocations of s3pypi do not overwrite each other's changes."
         ),
     )
-    p.add_argument("--put-root-index", action="store_true", help="Write a root index.")
+    p.add_argument(
+        "--put-root-index",
+        action="store_true",
+        help="Write a root index that lists all available package names.",
+    )
     p.add_argument("-f", "--force", action="store_true", help="Overwrite files.")
     p.add_argument("-v", "--verbose", action="store_true", help="Verbose output.")
     p.add_argument("-V", "--version", action="version", version=__version__)

--- a/s3pypi/core.py
+++ b/s3pypi/core.py
@@ -43,8 +43,11 @@ def upload_packages(
 ):
     session = boto3.Session(profile_name=profile, region_name=region)
     storage = S3Storage(session, bucket, **kwargs)
-    # TODO: Make table name customizable?
-    lock = DynamoDBLocker(session, table=bucket) if lock_indexes else DummyLocker()
+    lock = (
+        DynamoDBLocker(session, table=f"{bucket}-locks")
+        if lock_indexes
+        else DummyLocker()
+    )
 
     distributions = [parse_distribution(path) for path in dist]
     get_name = attrgetter("name")

--- a/s3pypi/core.py
+++ b/s3pypi/core.py
@@ -61,9 +61,8 @@ def upload_packages(
                 filename = distr.local_path.name
 
                 if not force and filename in index.filenames:
-                    log.warning(
-                        "%s already exists! (use --force to overwrite)", filename
-                    )
+                    msg = "%s already exists! (use --force to overwrite)"
+                    log.warning(msg, filename)
                 else:
                     log.info("Uploading %s", distr.local_path)
                     storage.put_distribution(directory, distr.local_path)

--- a/s3pypi/core.py
+++ b/s3pypi/core.py
@@ -36,6 +36,7 @@ def upload_packages(
     bucket: str,
     force: bool = False,
     lock_indexes: bool = False,
+    put_root_index: bool = False,
     profile: Optional[str] = None,
     region: Optional[str] = None,
     **kwargs,
@@ -67,11 +68,10 @@ def upload_packages(
 
             storage.put_index(directory, index)
 
-    root = storage.root
-    with lock(root):
-        index = storage.get_index(root)
-        # TODO: Update root index
-        storage.put_index(root, index)
+    if put_root_index:
+        with lock(storage.root):
+            index = storage.build_root_index()
+            storage.put_index(storage.root, index)
 
 
 def parse_distribution(path: Path) -> Distribution:

--- a/s3pypi/index.py
+++ b/s3pypi/index.py
@@ -16,7 +16,7 @@ class Index:
 
     def to_html(self) -> str:
         links = "<br>\n".join(
-            f'<a href="{urllib.parse.quote(fname)}">{fname}</a>'
+            f'<a href="{urllib.parse.quote(fname)}">{fname.rstrip("/")}</a>'
             for fname in sorted(self.filenames)
         )
         return index_html.format(body=indent(links, " " * 4))

--- a/s3pypi/locking.py
+++ b/s3pypi/locking.py
@@ -1,47 +1,75 @@
 import abc
+import datetime as dt
+import getpass
+import time
 from contextlib import contextmanager
 
 import boto3
 
 
+class LockTimeoutError(Exception):
+    def __init__(self, lock_id: str):
+        super().__init__(f"Timed out trying to acquire lock '{lock_id}'")
+
+
 class Locker(abc.ABC):
     @contextmanager
-    def __call__(self, key: str):
-        self._lock(key)
+    def __call__(self, lock_id: str):
+        self._lock(lock_id)
         try:
             yield
         finally:
-            self._unlock(key)
+            self._unlock(lock_id)
 
     @abc.abstractmethod
-    def _lock(self, key: str):
+    def _lock(self, lock_id: str):
         ...
 
     @abc.abstractmethod
-    def _unlock(self, key: str):
+    def _unlock(self, lock_id: str):
         ...
 
 
 class DummyLocker(Locker):
-    def _lock(self, key: str):
+    def _lock(self, lock_id: str):
         pass
 
     _unlock = _lock
 
 
-class DynamoDbLocker(Locker):
+class DynamoDBLocker(Locker):
     def __init__(
         self,
         session: boto3.session.Session,
         table: str,
-        timeout: int = 10,
+        poll_interval: int = 1,
+        max_attempts: int = 30,
     ):
         db = session.resource("dynamodb")
         self.table = db.Table(table)
-        self.timeout = timeout
+        self.exc = self.table.meta.client.exceptions
+        self.poll_interval = poll_interval
+        self.max_attempts = max_attempts
+        self.user = getpass.getuser()
 
-    def _lock(self, key: str):
-        raise NotImplementedError
+    def _lock(self, lock_id: str):
+        for attempt in range(1, self.max_attempts + 1):
+            now = dt.datetime.now(dt.timezone.utc)
+            try:
+                self.table.put_item(
+                    Item={
+                        "LockID": lock_id,
+                        "AcquiredAt": now.isoformat(),
+                        "Username": self.user,
+                    },
+                    ConditionExpression="attribute_not_exists(LockID)",
+                )
+                return
+            except self.exc.ConditionalCheckFailedException:
+                if attempt < self.max_attempts:
+                    time.sleep(self.poll_interval)
 
-    def _unlock(self, key: str):
-        raise NotImplementedError
+        raise LockTimeoutError(lock_id)
+
+    def _unlock(self, lock_id: str):
+        self.table.delete_item(Item={"LockID": lock_id})

--- a/s3pypi/locking.py
+++ b/s3pypi/locking.py
@@ -1,20 +1,17 @@
 import abc
 import datetime as dt
-import getpass
+import hashlib
+import json
 import time
 from contextlib import contextmanager
 
 import boto3
 
 
-class LockTimeoutError(Exception):
-    def __init__(self, lock_id: str):
-        super().__init__(f"Timed out trying to acquire lock '{lock_id}'")
-
-
 class Locker(abc.ABC):
     @contextmanager
-    def __call__(self, lock_id: str):
+    def __call__(self, key: str):
+        lock_id = hashlib.sha1(key.encode()).hexdigest()
         self._lock(lock_id)
         try:
             yield
@@ -43,14 +40,14 @@ class DynamoDBLocker(Locker):
         session: boto3.session.Session,
         table: str,
         poll_interval: int = 1,
-        max_attempts: int = 30,
+        max_attempts: int = 10,
     ):
         db = session.resource("dynamodb")
         self.table = db.Table(table)
         self.exc = self.table.meta.client.exceptions
         self.poll_interval = poll_interval
         self.max_attempts = max_attempts
-        self.user = getpass.getuser()
+        self.caller_id = session.client("sts").get_caller_identity()["Arn"]
 
     def _lock(self, lock_id: str):
         for attempt in range(1, self.max_attempts + 1):
@@ -60,7 +57,7 @@ class DynamoDBLocker(Locker):
                     Item={
                         "LockID": lock_id,
                         "AcquiredAt": now.isoformat(),
-                        "Username": self.user,
+                        "Owner": self.caller_id,
                     },
                     ConditionExpression="attribute_not_exists(LockID)",
                 )
@@ -69,7 +66,19 @@ class DynamoDBLocker(Locker):
                 if attempt < self.max_attempts:
                     time.sleep(self.poll_interval)
 
-        raise LockTimeoutError(lock_id)
+        item = self.table.get_item(Key={"LockID": lock_id})["Item"]
+        raise DynamoDBLockTimeoutError(self.table.name, item)
 
     def _unlock(self, lock_id: str):
         self.table.delete_item(Key={"LockID": lock_id})
+
+
+class DynamoDBLockTimeoutError(Exception):
+    def __init__(self, table: str, item: dict):
+        key = json.dumps({"LockID": {"S": item["LockID"]}})
+        super().__init__(
+            f"Timed out trying to acquire lock:\n\n{json.dumps(item, indent=2)}\n\n"
+            "Another instance of s3pypi may currently be holding the lock.\n"
+            "If this is not the case, you may release the lock as follows:\n\n"
+            f"$ aws dynamodb delete-item --table-name {table} --key '{key}'\n"
+        )

--- a/s3pypi/locking.py
+++ b/s3pypi/locking.py
@@ -1,0 +1,47 @@
+import abc
+from contextlib import contextmanager
+
+import boto3
+
+
+class Locker(abc.ABC):
+    @contextmanager
+    def __call__(self, key: str):
+        self._lock(key)
+        try:
+            yield
+        finally:
+            self._unlock(key)
+
+    @abc.abstractmethod
+    def _lock(self, key: str):
+        ...
+
+    @abc.abstractmethod
+    def _unlock(self, key: str):
+        ...
+
+
+class DummyLocker(Locker):
+    def _lock(self, key: str):
+        pass
+
+    _unlock = _lock
+
+
+class DynamoDbLocker(Locker):
+    def __init__(
+        self,
+        session: boto3.session.Session,
+        table: str,
+        timeout: int = 10,
+    ):
+        db = session.resource("dynamodb")
+        self.table = db.Table(table)
+        self.timeout = timeout
+
+    def _lock(self, key: str):
+        raise NotImplementedError
+
+    def _unlock(self, key: str):
+        raise NotImplementedError

--- a/s3pypi/locking.py
+++ b/s3pypi/locking.py
@@ -72,4 +72,4 @@ class DynamoDBLocker(Locker):
         raise LockTimeoutError(lock_id)
 
     def _unlock(self, lock_id: str):
-        self.table.delete_item(Item={"LockID": lock_id})
+        self.table.delete_item(Key={"LockID": lock_id})

--- a/s3pypi/storage.py
+++ b/s3pypi/storage.py
@@ -8,21 +8,22 @@ from s3pypi.index import Index
 
 
 class S3Storage:
+    root = "/"
+    _index = "index.html"
+
     def __init__(
         self,
+        session: boto3.session.Session,
         bucket: str,
-        profile: Optional[str] = None,
-        region: Optional[str] = None,
         prefix: Optional[str] = None,
         acl: Optional[str] = None,
         s3_put_args: Optional[dict] = None,
         unsafe_s3_website: bool = False,
     ):
-        session = boto3.Session(profile_name=profile, region_name=region)
         self.s3 = session.resource("s3")
         self.bucket = bucket
         self.prefix = prefix
-        self.index_name = "index.html" if unsafe_s3_website else ""
+        self.index_name = self._index if unsafe_s3_website else ""
         self.put_kwargs = dict(
             ACL=acl or "private",
             **(s3_put_args or {}),
@@ -30,9 +31,11 @@ class S3Storage:
 
     def _object(self, directory: str, filename: str):
         parts = [directory, filename]
+        if parts == [self.root, self.index_name]:
+            parts = [self._index]
         if self.prefix:
             parts.insert(0, self.prefix)
-        return self.s3.Object(self.bucket, "/".join(parts))
+        return self.s3.Object(self.bucket, key="/".join(parts))
 
     def get_index(self, directory: str) -> Index:
         try:

--- a/terraform/modules/s3pypi/main.tf
+++ b/terraform/modules/s3pypi/main.tf
@@ -67,6 +67,8 @@ resource "aws_cloudfront_distribution" "cdn" {
     error_caching_min_ttl = 0
   }
 
+  default_root_object = "index.html"
+
   default_cache_behavior {
     target_origin_id       = "s3"
     viewer_protocol_policy = "redirect-to-https"

--- a/terraform/modules/s3pypi/main.tf
+++ b/terraform/modules/s3pypi/main.tf
@@ -14,6 +14,12 @@ variable "use_wildcard_certificate" {
   description = "Use a wildcard certificate (*.example.com)"
 }
 
+variable "enable_dynamodb_locking" {
+  type        = bool
+  default     = false
+  description = "Create a DynamoDB table for locking"
+}
+
 variable "enable_basic_auth" {
   type        = bool
   default     = false
@@ -140,6 +146,19 @@ data "aws_iam_policy_document" "s3_policy" {
       type        = "AWS"
       identifiers = [aws_cloudfront_origin_access_identity.oai.iam_arn]
     }
+  }
+}
+
+resource "aws_dynamodb_table" "locks" {
+  count = var.enable_dynamodb_locking ? 1 : 0
+
+  name         = "${var.bucket}-locks"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
   }
 }
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -35,3 +35,8 @@ def s3_bucket(aws_credentials):
         bucket = conn.Bucket("s3pypi-test")
         bucket.create()
         yield bucket
+
+
+@pytest.fixture
+def boto3_session(s3_bucket):
+    return boto3.session.Session()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,8 +2,8 @@ import os
 from contextlib import contextmanager
 
 import boto3
+import moto
 import pytest
-from moto import mock_s3
 
 
 @pytest.fixture(scope="session")
@@ -26,15 +26,29 @@ def aws_credentials():
     os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
     os.environ["AWS_SECURITY_TOKEN"] = "testing"
     os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
 
 
 @pytest.fixture
 def s3_bucket(aws_credentials):
-    with mock_s3():
-        conn = boto3.resource("s3", region_name="us-east-1")
-        bucket = conn.Bucket("s3pypi-test")
+    with moto.mock_s3():
+        s3 = boto3.resource("s3")
+        bucket = s3.Bucket("s3pypi-test")
         bucket.create()
         yield bucket
+
+
+@pytest.fixture
+def dynamodb_table(s3_bucket):
+    name = f"{s3_bucket.name}-locks"
+    with moto.mock_dynamodb2(), moto.mock_sts():
+        db = boto3.resource("dynamodb")
+        db.create_table(
+            TableName=name,
+            AttributeDefinitions=[{"AttributeName": "LockID", "AttributeType": "S"}],
+            KeySchema=[{"AttributeName": "LockID", "KeyType": "HASH"}],
+        )
+        yield db.Table(name)
 
 
 @pytest.fixture

--- a/tests/integration/test_locking.py
+++ b/tests/integration/test_locking.py
@@ -1,0 +1,18 @@
+import pytest
+
+from s3pypi.locking import DynamoDBLocker, DynamoDBLockTimeoutError
+
+
+def test_dynamodb_lock_timeout(boto3_session, dynamodb_table):
+    lock = DynamoDBLocker(
+        boto3_session,
+        dynamodb_table.name,
+        poll_interval=0.01,
+        max_attempts=3,
+    )
+    key = "example"
+
+    with lock(key):
+        with pytest.raises(DynamoDBLockTimeoutError):
+            with lock(key):
+                pass

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -23,14 +23,17 @@ def test_string_dict(text, expected):
 def test_main_upload_package(chdir, data_dir, s3_bucket):
     with chdir(data_dir):
         dist = sorted(glob.glob("dists/*"))
-        s3pypi(*dist, "--bucket", s3_bucket.name)
+        s3pypi(*dist, "--bucket", s3_bucket.name, "--put-root-index")
 
     def read(key: str) -> bytes:
         return s3_bucket.Object(key).get()["Body"].read()
 
+    root_index = read("index.html").decode()
+
     def assert_pkg_exists(prefix: str, filename: str):
         assert read(prefix + filename)
         assert f">{filename}</a>" in read(prefix).decode()
+        assert f">{prefix.rstrip('/')}</a>" in root_index
 
     assert_pkg_exists("foo/", "foo-0.1.0.tar.gz")
     assert_pkg_exists("hello-world/", "hello_world-0.1.0-py3-none-any.whl")

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -20,10 +20,10 @@ def test_string_dict(text, expected):
     assert string_dict(text) == expected
 
 
-def test_main_upload_package(chdir, data_dir, s3_bucket):
+def test_main_upload_package(chdir, data_dir, s3_bucket, dynamodb_table):
     with chdir(data_dir):
         dist = sorted(glob.glob("dists/*"))
-        s3pypi(*dist, "--bucket", s3_bucket.name, "--put-root-index")
+        s3pypi(*dist, "--bucket", s3_bucket.name, "--lock-indexes", "--put-root-index")
 
     def read(key: str) -> bytes:
         return s3_bucket.Object(key).get()["Body"].read()

--- a/tests/integration/test_storage.py
+++ b/tests/integration/test_storage.py
@@ -2,21 +2,21 @@ from s3pypi.index import Index
 from s3pypi.storage import S3Storage
 
 
-def test_index_storage_roundtrip(s3_bucket):
+def test_index_storage_roundtrip(boto3_session, s3_bucket):
     directory = "foo"
     index = Index({"bar"})
 
-    storage = S3Storage(s3_bucket.name)
+    storage = S3Storage(boto3_session, s3_bucket.name)
     storage.put_index(directory, index)
     got = storage.get_index(directory)
 
     assert got == index
 
 
-def test_prefix_in_s3_key():
+def test_prefix_in_s3_key(boto3_session):
     prefix = "1234567890"
 
-    storage = S3Storage(bucket="example", prefix=prefix)
+    storage = S3Storage(boto3_session, bucket="example", prefix=prefix)
     obj = storage._object(directory="foo", filename="bar")
 
     assert obj.key.startswith(prefix + "/")


### PR DESCRIPTION
This is a starting point for the changes related to locking discussed in #18.

To do:
- [x] Add Terraform config for creating the DynamoDB table (should be opt-in).
- [x] Implement lock and unlock methods.
- [x] Make AWS profile and region configurable for DynamoDB client.
- [x] (Optional) Update the root index (this may become a separate PR).
- [x] Add tests.
- [x] Update changelog and README.

Fixes #18, closes #26.